### PR TITLE
Disable EmptyRule scss linter

### DIFF
--- a/configs/scss-lint-foundation6.yml
+++ b/configs/scss-lint-foundation6.yml
@@ -39,7 +39,7 @@ linters:
     ignore_single_line_blocks: true
 
   EmptyRule:
-    enabled: true
+    enabled: false
 
   FinalNewline:
     enabled: true


### PR DESCRIPTION
Empty rules are removed by cssnano and they are good as a reference.
